### PR TITLE
add alt tag to <img>twitter</img>

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,7 +137,7 @@
             <i class="fab fa-instagram"></i>
           </a>&nbsp; &nbsp;
           <a href="https://twitter.com/flux_capacitir">
-            <img style="border-radius: 20%; width: 40px;"src="img/flux.JPG"></i>
+            <img style="border-radius: 20%; width: 40px;"src="img/flux.JPG" alt="image of a flux capacitor; the link directs to twitter, my handle is flux_capacitir"></i>
           </a>
 
         </div>


### PR DESCRIPTION
# Description
accessibility audit improvements

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What Changed:
Add appropriate alternative text that presents the content of the image and/or the function of the link.

## Why It Matters
Images that are the only thing within a link must have descriptive alternative text. If an image is within a link that contains no text and that image does not provide alternative text, a screen reader has no content to present to the user regarding the function of the link.

## Testing Instructions for Change Made

input 'gradyrobbins.com' into the wave [tool
](https://wave.webaim.org/report#/www.gradyrobbins.com) 

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [x] I have added test instructions that prove my fix is effective or that my feature works
