### PR TITLE
accessibility audit:  3 Errors 3 X Empty link

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,17 +91,17 @@
         <br />
 
         <div class="social-icons">
-          <a href="https://www.linkedin.com/in/grady-robbins/">
+          <a href="https://www.linkedin.com/in/grady-robbins/" alt="Link to Grady's Linkedin account">
             <i class="fab fa-linkedin-in"></i>
-          </a>&nbsp; &nbsp;
-          <a href="https://github.com/gradyrobbins/">
+          </a>
+          <a href="https://github.com/gradyrobbins/"alt="Link to Grady's GitHub account">
             <i class="fab fa-github"></i>
-          </a>&nbsp; &nbsp;
-          <a href="https://www.instagram.com/grady.robbins/">
+          </a>
+          <a href="https://www.instagram.com/grady.robbins/"alt="Link to Grady's Instagram account">
             <i class="fab fa-instagram"></i>
-          </a>&nbsp; &nbsp;
+          </a>
           <a href="https://twitter.com/flux_capacitir">
-            <img style="border-radius: 20%; width: 40px;"src="img/flux.JPG" alt="image of a flux capacitor; the link directs to twitter, my handle is flux_capacitir"></i>
+            <img style="border-radius: 20%; width: 40px;"src="img/flux.JPG" alt="Link to Grady's Twitter account"></img>
           </a>
 
         </div>


### PR DESCRIPTION
add href info to Social Media anchor and <i> tags for accessibility: alt=Link to Grady's Linkedin account etc.

**What It Means**
A link contains no text.

**Why It Matters**
If a link contains no text, the function or purpose of the link will not be presented to the user. This can introduce confusion for keyboard and screen reader users.

**What To Do**
Remove the empty link or provide text within the link that describes the functionality and/or target of that link.

**The Algorithm... _in English_** 
An anchor element has an href attribute, but contains no text (or only spaces) and no images with alternative text.