### PR TITLE
remove sr-only text and <a> for accessibility audit

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,6 @@
 <body id="page-top">
 
   <nav class="navbar navbar-expand-lg navbar-dark bg-primary fixed-top" id="sideNav">
-    <a href="mailto:gradyrobbins13@gmail.com" target="_blank" ><span class="sr-only">email Grady</span></a>
 
     <h2><br /><a href="mailto:gradyrobbins13@gmail.com" target="_blank"><i class="fas fa-envelope"></i> &nbsp;GRADY ROBBINS</a></h2>
 


### PR DESCRIPTION
# Description
WAVE / WEBAIM audit findings:
1 X Very low contrast 



## Type of change
removed this code block:  
```
<a href="mailto:gradyrobbins13@gmail.com" target="_blank">
Very small textVery low contrast
<span class="sr-only" style="color: rgb(0, 155, 200); background-color: rgb(53, 52, 79);">
email Grady
</span>
</a>
```

# Testing Instructions for Change Made
Go to:
https://wave.webaim.org/report#/www.gradyrobbins.com
- [ ] Verify that these changes generate no new warnings


